### PR TITLE
Document lime.ndll requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Converter of FNF or osu!mania maps/charts, example from 4 key to 6 key, now with
 ## (Latest) 3.0.5 - sliders update
 - Now u can change value of sliders with double click on it (feat. [ZeroSupply](https://gamebanana.com/members/2007471))
 - Fixed colors and updated hxcpp to 4.3.2
-- Now it not using lime things so u can remove lime.ndll
+- The application still depends on Lime; keep lime.ndll next to the executable to avoid a "Could not load module lime@lime_application_create__prime" error
 - Changed bf to pico and vice versa (im idiot)
 - Fixed watermark
 - Fixed unvisible buttons on web version smh idk (feat. [Binsu1126](https://gamebanana.com/members/2297338))

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,7 +2,7 @@
 1. Install [**haxe**](https://haxe.org)
 2. Do these commands in cmd:
 ```
-haxelib install hxcpp 4.2.1
+haxelib install hxcpp 4.3.2
 haxelib install lime 8.0.2
 haxelib install openfl 9.2.2
 haxelib install flixel 5.3.1
@@ -22,3 +22,4 @@ MSVC v142 - C++ x64/x86 build tools
 Windows SDK
 ```
 6. And now compile it with: `lime test <windows/linux/mac>`
+7. After compilation, keep the `lime.ndll` file in the same directory as the `ManiaConverter` executable. Removing it will lead to the startup error "Could not load module lime@lime_application_create__prime".

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -3,7 +3,7 @@
 ## 3.0.5 - sliders update
 - Now u can change value of sliders with double click on it (feat. [ZeroSupply](https://gamebanana.com/members/2007471))
 - Fixed colors and updated hxcpp to 4.3.2
-- Now it not using lime things so u can remove lime.ndll
+- The application still relies on Lime; keep lime.ndll with the executable to prevent a "Could not load module lime@lime_application_create__prime" error
 - Changed bf to pico and vice versa (im idiot)
 - Fixed watermark
 - Fixed unvisible buttons on web version smh idk (feat. [Binsu1126](https://gamebanana.com/members/2297338))


### PR DESCRIPTION
## Summary
- Clarify in README and changelog that Lime's `lime.ndll` is still required at runtime
- Update build instructions to match hxcpp 4.3.2 and warn about missing `lime.ndll`

## Testing
- `haxe --version` *(fails: command not found)*
- `haxelib list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ae34d3e0832eb7321d7f62e85a85